### PR TITLE
save the icon visibility status in double click mode across reboots

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -136,7 +136,12 @@
       <label></label>
       <default>true</default>
     </entry>
-    
+
+    <entry name="iconsHidden" type="Bool">
+      <label> Whether currently the icons are hidden or not if user uses the double click to hide/unhide them</label>
+      <default>true</default>
+    </entry>
+
     <entry name="userdefinedback" type="Bool">
       <label>.</label>
       <default>false</default>

--- a/contents/ui/FolderView.qml
+++ b/contents/ui/FolderView.qml
@@ -67,7 +67,13 @@ FocusScope {
     property var dialog: null
     property Item editor: null
     
-    property bool iconos: true
+    property bool iconos: plasmoid.configuration.iconsHidden
+
+    Binding {
+        target: plasmoid.configuration
+        property: "iconsHidden"
+        value: iconos
+    }
 
     function positionViewAtBeginning() {
         gridView.positionViewAtBeginning();
@@ -346,7 +352,7 @@ FocusScope {
                 if(doubleOnNothing){
                     doubleOnNothing=false
                     if(plasmoid.configuration.doubleclickhide){
-                        iconos= iconos?false:true
+                        iconos = !iconos
                     }
                 }else{
                     doubleOnNothing=true
@@ -1115,10 +1121,7 @@ FocusScope {
                         gridView.iconSize = gridView.makeIconSize();
                     }
                     
-                    onDoubleclickhideChanged:{
-                        if(!plasmoid.configuration.doubleclickhide){iconos= true}
-                        
-                    }
+                    onDoubleclickhideChanged: iconos = true
                 }
                 
                 Connections {


### PR DESCRIPTION
This folder view is awesome and let me hide/unhide icons by double clicking which I miss from my windows days. This PR make it save the last visibility status of icons so that hidden icons do not become unhidden after reboot. I have also made some other minor changes which should be self evident.